### PR TITLE
x-z typo in 2020-07-16-z-domain-analysis.md

### DIFF
--- a/_posts/2020-07-16-z-domain-analysis.md
+++ b/_posts/2020-07-16-z-domain-analysis.md
@@ -52,7 +52,7 @@ We want to find an expression $Y(z)$ for an input $X(z)$. That means we must con
 
 That yields:
 
-++Y(z) = X(z) + Y(z)\cdot x^{-1}++
+++Y(z) = X(z) + Y(z)\cdot z^{-1}++
 
 ++\frac{Y(z)}{X(z)} = \frac{1}{1-z^{-1}}++
 


### PR DESCRIPTION
The delay operation in z-transform should be represented by multiplication by z^-1.  Clearly you meant to write z instead of x here, because the subsequent equation correctly uses z^-1.

Just trying to fix a typo out of an otherwise very informative blog post, thanks!